### PR TITLE
Consistently use the Jest matchers in the unit tests

### DIFF
--- a/packages/cli/src/test/wgsl-link.test.ts
+++ b/packages/cli/src/test/wgsl-link.test.ts
@@ -19,7 +19,7 @@ test("link with definition", async () => {
        ./src/test/wgsl/util.wgsl
        --define EXTRA=true`
   );
-  expect(logged).to.include("fn extra()");
+  expect(logged).toContain("fn extra()");
 });
 
 async function cliLine(argsLine: string): Promise<string> {

--- a/packages/linker/src/test/Conditionals.test.ts
+++ b/packages/linker/src/test/Conditionals.test.ts
@@ -11,7 +11,7 @@ test("parse #if #endif", () => {
     `;
 
   const sourceMap = processConditionals(src, { foo: true });
-  expect(sourceMap.dest).contains("fn f() { }");
+  expect(sourceMap.dest).toContain("fn f() { }");
   expect(sourceMap.entries).toMatchInlineSnapshot(`
     [
       {
@@ -58,7 +58,7 @@ test("parse // #if !foo", () => {
     // #endif 
     `;
   const { dest } = processConditionals(src, { foo: false });
-  expect(dest).contains("fn f() { }");
+  expect(dest).toContain("fn f() { }");
 });
 
 test("parse #if !foo (true)", () => {
@@ -69,8 +69,8 @@ test("parse #if !foo (true)", () => {
     `;
   expectNoLogErr(() => {
     const { dest } = processConditionals(src, { foo: true });
-    expect(dest).not.contains("fn");
-    expect(dest).not.contains("//");
+    expect(dest).not.toContain("fn");
+    expect(dest).not.toContain("//");
   });
 });
 
@@ -83,8 +83,8 @@ test("parse #if !foo #else #endif", () => {
     // #endif 
     `;
   const { dest } = processConditionals(src, { foo: true });
-  expect(dest).contains("fn g()");
-  expect(dest).not.contains("fn f()");
+  expect(dest).toContain("fn g()");
+  expect(dest).not.toContain("fn f()");
 });
 
 test("parse nested #if", () => {
@@ -103,9 +103,9 @@ test("parse nested #if", () => {
     #endif 
     `;
   const { dest } = processConditionals(src, { foo: true, zap: true });
-  expect(dest).contains("fn zap()");
-  expect(dest).contains("fn g()");
-  expect(dest).not.contains("fn f()");
+  expect(dest).toContain("fn zap()");
+  expect(dest).toContain("fn g()");
+  expect(dest).not.toContain("fn f()");
 });
 
 test("parse #if #endif with extra space", () => {
@@ -116,7 +116,7 @@ test("parse #if #endif with extra space", () => {
     `;
 
   const { dest } = processConditionals(src, {});
-  expect(dest).not.contains("fn f() { }");
+  expect(dest).not.toContain("fn f() { }");
 });
 
 test("parse last line", () => {
@@ -124,7 +124,7 @@ test("parse last line", () => {
     #x
     y`;
   const { dest } = processConditionals(src, {});
-  expect(dest).eq(src);
+  expect(dest).toBe(src);
 });
 
 test("srcLog with srcMap", () => {

--- a/packages/linker/src/test/Extends.test.ts
+++ b/packages/linker/src/test/Extends.test.ts
@@ -210,5 +210,5 @@ test.skip("extend struct with rename", () => {
     `;
 
   const linked = linkTest(src, module1);
-  expect(linked).includes("fill: vec4f");
+  expect(linked).toContain("fill: vec4f");
 });

--- a/packages/linker/src/test/GleamImport.test.ts
+++ b/packages/linker/src/test/GleamImport.test.ts
@@ -4,14 +4,14 @@ import { gleamImport } from "../GleamImport.js";
 
 function expectParses(ctx: TaskContext): TestParseResult<void> {
   const result = testParse(gleamImport, ctx.task.name);
-  expect(result.parsed).is.not.null;
+  expect(result.parsed).not.toBeNull();
   return result;
 }
 /* ------  success cases  -------   */
 
 test("import ./foo/bar;", (ctx) => {
   const result = expectParses(ctx);
-  expect(result.position).eq(ctx.task.name.length); // consume semicolon (so that linking will remove it)
+  expect(result.position).toBe(ctx.task.name.length); // consume semicolon (so that linking will remove it)
 });
 
 test("import foo-bar/boo", (ctx) => {

--- a/packages/linker/src/test/ImportCases.test.ts
+++ b/packages/linker/src/test/ImportCases.test.ts
@@ -142,7 +142,6 @@ test("import and resolve conflicting support function", (ctx) => {
   });
 });
 
-
 test("import support fn that references another import", (ctx) => {
   linkTest(ctx.task.name, {
     linked: `
@@ -187,7 +186,6 @@ test("import support fn from two exports", (ctx) => {
   });
 });
 
-
 test("import a struct", (ctx) => {
   linkTest(ctx.task.name, {
     linked: `
@@ -201,7 +199,6 @@ test("import a struct", (ctx) => {
     `,
   });
 });
-
 
 test("import fn with support struct constructor", (ctx) => {
   linkTest(ctx.task.name, {
@@ -220,7 +217,6 @@ test("import fn with support struct constructor", (ctx) => {
     `,
   });
 });
-
 
 test("import a transitive struct", (ctx) => {
   linkTest(ctx.task.name, {
@@ -321,18 +317,18 @@ function linkTest(name: string, expectation: LinkExpectation): void {
       const expectLines = expectTrimmed.split("\n");
       const resultLines = result.split("\n");
       expectLines.forEach((line, i) => {
-        expect(resultLines[i]).eq(line);
+        expect(resultLines[i]).toBe(line);
       });
     }
   }
   if (includes !== undefined) {
     includes.forEach((inc) => {
-      expect(result).includes(inc);
+      expect(result).toContain(inc);
     });
   }
   if (excludes !== undefined) {
     excludes.forEach((exc) => {
-      expect(result).not.includes(exc);
+      expect(result).not.toContain(exc);
     });
   }
 }

--- a/packages/linker/src/test/ImportResolutionMap.test.ts
+++ b/packages/linker/src/test/ImportResolutionMap.test.ts
@@ -1,6 +1,10 @@
 import { expect, test } from "vitest";
 import { importResolutionMap } from "../ImportResolutionMap.js";
-import { exportsToStrings, logResolveMap, pathsToStrings } from "../LogResolveMap.js";
+import {
+  exportsToStrings,
+  logResolveMap,
+  pathsToStrings,
+} from "../LogResolveMap.js";
 import { ModuleRegistry } from "../ModuleRegistry.js";
 import { TextExport } from "../ParseModule.js";
 
@@ -24,16 +28,16 @@ test("simple tree", () => {
   const treeImports = impMod.imports.filter((i) => i.kind === "treeImport");
   const resolveMap = importResolutionMap(impMod, treeImports, parsedModules);
 
-  expect(resolveMap.exportMap.size).eq(1);
+  expect(resolveMap.exportMap.size).toBe(1);
   const [impPath, impToExp] = [...resolveMap.exportMap.entries()][0];
-  expect(impPath).eq("bar/foo");
-  expect(impToExp.modExp.module.modulePath).eq("bar");
-  expect((impToExp.modExp.exp as TextExport).ref.name).eq("foo");
+  expect(impPath).toBe("bar/foo");
+  expect(impToExp.modExp.module.modulePath).toBe("bar");
+  expect((impToExp.modExp.exp as TextExport).ref.name).toBe("foo");
 
-  expect(resolveMap.pathsMap.length).eq(1);
+  expect(resolveMap.pathsMap.length).toBe(1);
   const [impSegments, expSegments] = resolveMap.pathsMap[0];
-  expect(impSegments).deep.eq(["bar", "foo"]);
-  expect(expSegments).eq("bar/foo");
+  expect(impSegments).toEqual(["bar", "foo"]);
+  expect(expSegments).toBe("bar/foo");
 });
 
 test("tree with path segment list", () => {
@@ -54,11 +58,11 @@ test("tree with path segment list", () => {
   const impMod = parsedModules.findTextModule("./main")!;
   const treeImports = impMod.imports.filter((i) => i.kind === "treeImport");
   const resolveMap = importResolutionMap(impMod, treeImports, parsedModules);
-  expect(pathsToStrings(resolveMap)).deep.eq([
+  expect(pathsToStrings(resolveMap)).toEqual([
     "bar/foo -> bar/foo",
     "bar/zah -> bar/zah",
   ]);
-  expect(exportsToStrings(resolveMap)).deep.eq([
+  expect(exportsToStrings(resolveMap)).toEqual([
     "bar/foo -> bar/foo",
     "bar/zah -> bar/zah",
   ]);
@@ -83,11 +87,11 @@ test.skip("tree with trailing wildcard", () => {
   const treeImports = impMod.imports.filter((i) => i.kind === "treeImport");
   const resolveMap = importResolutionMap(impMod, treeImports, parsedModules);
   logResolveMap(resolveMap);
-  // expect(pathsToStrings(resolveMap)).deep.eq([
+  // expect(pathsToStrings(resolveMap)).toEqual([
   //   "bar/foo -> bar/foo",
   //   "bar/zah -> bar/zah",
   // ]);
-  // expect(exportsToStrings(resolveMap)).deep.eq([
+  // expect(exportsToStrings(resolveMap)).toEqual([
   //   "bar/foo -> bar/foo",
   //   "bar/zah -> bar/zah",
   // ]);

--- a/packages/linker/src/test/ImportSyntaxCases.test.ts
+++ b/packages/linker/src/test/ImportSyntaxCases.test.ts
@@ -1,23 +1,23 @@
 import { testParse, TestParseResult } from "mini-parse/test-util";
 import { expect, test } from "vitest";
-import { importSyntaxCases } from "wesl-testsuite"
+import { importSyntaxCases } from "wesl-testsuite";
 import { gleamImport } from "../GleamImport.js";
 
 function expectParseFail(src: string): void {
   const result = testParse(gleamImport, src);
-  expect(result.parsed).is.null;
+  expect(result.parsed).toBeNull();
 }
 
 function expectParses(src: string): TestParseResult<void> {
   const result = testParse(gleamImport, src);
-  expect(result.parsed).is.not.null;
+  expect(result.parsed).not.toBeNull();
   return result;
 }
 
-  importSyntaxCases.forEach((c) => {
-    if (c.fails) {
-      test(c.src, () => expectParseFail(c.src));
-    } else {
-      test(c.src, () => expectParses(c.src));
-    }
-  });
+importSyntaxCases.forEach((c) => {
+  if (c.fails) {
+    test(c.src, () => expectParseFail(c.src));
+  } else {
+    test(c.src, () => expectParses(c.src));
+  }
+});

--- a/packages/linker/src/test/Importing.test.ts
+++ b/packages/linker/src/test/Importing.test.ts
@@ -20,9 +20,9 @@ test.skip("transitive with importing", () => {
       reduceWorkgroup(localId); // call the imported function
     }`;
   const linked = linkTest(src, binOpModule, reduceModule);
-  expect(linked).includes("myWork[index]");
-  expect(linked).not.includes("work[");
-  expect(linked).includes("binOpImpl");
+  expect(linked).toContain("myWork[index]");
+  expect(linked).not.toContain("work[");
+  expect(linked).toContain("binOpImpl");
 });
 
 test.skip("#export importing", () => {
@@ -38,5 +38,5 @@ test.skip("#export importing", () => {
     #export(X)
     fn bar(x:X) { } `;
   const linked = linkTest(src, module1, module2);
-  expect(linked).contains("fn bar(x:B)");
+  expect(linked).toContain("fn bar(x:B)");
 });

--- a/packages/linker/src/test/LinkGlob.test.ts
+++ b/packages/linker/src/test/LinkGlob.test.ts
@@ -5,21 +5,21 @@ import { ModuleRegistry } from "../ModuleRegistry.js";
 const wgsl1: Record<string, string> = import.meta.glob("./wgsl_1/*.wgsl", {
   query: "?raw",
   eager: true,
-  import: "default"
+  import: "default",
 });
 
 const wgsl2: Record<string, string> = import.meta.glob("./wgsl_2/*.wgsl", {
   query: "?raw",
   eager: true,
-  import: "default"
+  import: "default",
 });
 
 test("basic import glob", async () => {
   const linked = new ModuleRegistry({ wgsl: wgsl1 }).link("main");
-  expect(linked).contains("fn bar()");
+  expect(linked).toContain("fn bar()");
 });
 
 test("#import from path ./util", async () => {
   const linked = new ModuleRegistry({ wgsl: wgsl2 }).link("main2");
-  expect(linked).contains("fn bar()");
+  expect(linked).toContain("fn bar()");
 });

--- a/packages/linker/src/test/LinkPackage.test.ts
+++ b/packages/linker/src/test/LinkPackage.test.ts
@@ -20,5 +20,5 @@ test("import rand() from a package", () => {
 
   const registry = new ModuleRegistry({ wgsl, libs: [lib] });
   const result = registry.link("./main");
-  expect(result).includes("fn pcg_2u_3f");
+  expect(result).toContain("fn pcg_2u_3f");
 });

--- a/packages/linker/src/test/Linker.test.ts
+++ b/packages/linker/src/test/Linker.test.ts
@@ -13,7 +13,7 @@ test("ext params don't replace override", () => {
   `;
 
   const linked = linkTestOpts({ runtimeParams: { workgroupSizeX: 4 } }, src);
-  expect(linked).contains("override workgroupSizeX = 4u;");
+  expect(linked).toContain("override workgroupSizeX = 4u;");
 });
 
 test("import using replace template and ext param", () => {
@@ -35,7 +35,7 @@ test("import using replace template and ext param", () => {
   const templates = [simpleTemplate];
   const runtimeParams = { Threads: 128 };
   const linked = linkTestOpts({ templates, runtimeParams }, src, module1);
-  expect(linked).contains("step < 128");
+  expect(linked).toContain("step < 128");
 });
 
 test("#template in src", () => {
@@ -49,10 +49,8 @@ test("#template in src", () => {
   const templates = [simpleTemplate];
   const runtimeParams = { threads: 128 };
   const linked = linkTestOpts({ templates, runtimeParams }, src);
-  expect(linked).includes("step < 128");
+  expect(linked).toContain("step < 128");
 });
-
-
 
 /** requires 'module' syntax, which may not make the shared design */
 test("import foo from zap (multiple modules)", () => {
@@ -74,7 +72,7 @@ test("import foo from zap (multiple modules)", () => {
   `;
 
   const linked = linkTest(src, module1, module2);
-  expect(linked).contains("/* module2 */");
+  expect(linked).toContain("/* module2 */");
 });
 
 test("import with parameter", () => {
@@ -92,7 +90,7 @@ test("import with parameter", () => {
     }
   `;
   const linked = linkTest(src, myModule);
-  expect(linked).includes("a: MyElem");
+  expect(linked).toContain("a: MyElem");
 });
 
 test("#import twice with different params", () => {
@@ -111,8 +109,8 @@ test("#import twice with different params", () => {
   `;
 
   const linked = linkTest(src, module0);
-  expect(linked).includes("fn bar(x:B) { /* B */ }");
-  expect(linked).includes("fn foo(x:A) { /* A */ }");
+  expect(linked).toContain("fn bar(x:B) { /* B */ }");
+  expect(linked).toContain("fn foo(x:A) { /* A */ }");
 });
 
 test("import a struct with imp/exp params", () => {
@@ -132,7 +130,7 @@ test("import a struct with imp/exp params", () => {
   `;
 
   const linked = linkTest(src, module1);
-  expect(linked).contains("x: i32");
+  expect(linked).toContain("x: i32");
 });
 
 test("#import using simple template and imp/exp param", () => {
@@ -156,8 +154,8 @@ test("#import using simple template and imp/exp param", () => {
   const templates = [simpleTemplate];
   const runtimeParams = { Foo: "Bar" };
   const linked = linkTestOpts({ templates, runtimeParams }, src, module1);
-  expect(linked).contains("step < 128");
-  expect(linked).contains("/* Bar */");
+  expect(linked).toContain("step < 128");
+  expect(linked).toContain("/* Bar */");
 });
 
 test("#import using external param", () => {
@@ -177,7 +175,7 @@ test("#import using external param", () => {
 
   const runtimeParams = { workgroupSize: 128 };
   const linked = linkTestOpts({ runtimeParams }, src, module1);
-  expect(linked).contains("step < 128");
+  expect(linked).toContain("step < 128");
 });
 
 test("external param w/o ext. prefix doesn't override imp/exp params", () => {
@@ -197,8 +195,8 @@ test("external param w/o ext. prefix doesn't override imp/exp params", () => {
   `;
   const runtimeParams = { workgroupThreads: 128 };
   const linked = linkTestOpts({ runtimeParams }, src, module1);
-  expect(linked).not.includes("step < 128");
-  expect(linked).includes("step < workgroupThreads");
+  expect(linked).not.toContain("step < 128");
+  expect(linked).toContain("step < workgroupThreads");
 });
 
 test("import with simple template", () => {
@@ -217,5 +215,5 @@ test("import with simple template", () => {
     templates: [simpleTemplate],
   });
   const linked = registry.link("./main", { WORKGROUP_SIZE: "128" });
-  expect(linked).includes("step < 128");
+  expect(linked).toContain("step < 128");
 });

--- a/packages/linker/src/test/LinkerGenerator.test.ts
+++ b/packages/linker/src/test/LinkerGenerator.test.ts
@@ -8,7 +8,7 @@ const fooGenerator: RegisterGenerator = {
   generate: (fnName: string, params: Record<string, string>): string => {
     return `fn ${fnName}() { /* ${params.name}Impl */ }`;
   },
-  args: ["name"]
+  args: ["name"],
 };
 
 test("#import from code generator", () => {
@@ -19,10 +19,10 @@ test("#import from code generator", () => {
   `;
   const registry = new ModuleRegistry({
     wgsl: { "./main.wgsl": src },
-    generators: [fooGenerator]
+    generators: [fooGenerator],
   });
   const linked = registry.link("./main");
-  expect(linked).contains("barImpl");
+  expect(linked).toContain("barImpl");
 });
 
 test("#import as from code generator", () => {
@@ -33,10 +33,10 @@ test("#import as from code generator", () => {
   `;
   const registry = new ModuleRegistry({
     wgsl: { "./main.wgsl": src },
-    generators: [fooGenerator]
+    generators: [fooGenerator],
   });
   const linked = registry.link("./main");
-  expect(linked).contains("fn zip()");
+  expect(linked).toContain("fn zip()");
 });
 
 test("#import with arg from code generator", () => {
@@ -47,10 +47,10 @@ test("#import with arg from code generator", () => {
   `;
   const registry = new ModuleRegistry({
     wgsl: { "./main": src },
-    generators: [fooGenerator]
+    generators: [fooGenerator],
   });
   const linked = registry.link("./main");
-  expect(linked).contains("barImpl");
+  expect(linked).toContain("barImpl");
 });
 
 test("#import with ext.arg from code generator", () => {
@@ -61,10 +61,10 @@ test("#import with ext.arg from code generator", () => {
   `;
   const registry = new ModuleRegistry({
     wgsl: { "./main": src },
-    generators: [fooGenerator]
+    generators: [fooGenerator],
   });
   const linked = registry.link("./main", { zee: "zog" });
-  expect(linked).contains("zogImpl");
+  expect(linked).toContain("zogImpl");
 });
 
 test("#import conficted code gen fn", () => {
@@ -82,12 +82,12 @@ test("#import conficted code gen fn", () => {
   `;
 
   const generators = [fooGenerator];
-  const runtimeParams = {zee: "zog"};
-  const linked = linkTestOpts({ generators, runtimeParams}, src, module0)
+  const runtimeParams = { zee: "zog" };
+  const linked = linkTestOpts({ generators, runtimeParams }, src, module0);
 
-  expect(linked).contains("booImpl");
-  expect(linked).contains("fn foo0()");
-  expect(linked).contains("foo0();");
+  expect(linked).toContain("booImpl");
+  expect(linked).toContain("fn foo0()");
+  expect(linked).toContain("foo0();");
 });
 
 test("external param applied to generator", () => {
@@ -108,15 +108,15 @@ test("external param applied to generator", () => {
     name: "foo",
     args: ["threads"],
     generate,
-    moduleName: "test.module"
+    moduleName: "test.module",
   };
 
   const registry = new ModuleRegistry({
     wgsl: { "./main": src },
-    generators: [gen]
+    generators: [gen],
   });
   const linked = registry.link("./main", { workgroupThreads: 128 });
-  expect(linked).includes("step < 128");
+  expect(linked).toContain("step < 128");
 });
 
 // test("#import code generator snippet with support", () => {
@@ -136,6 +136,6 @@ test("external param applied to generator", () => {
 //   const registry = new ModuleRegistry();
 //   registry.registerGenerator("log", generate as CodeGenFn, ["name", "logType"]);
 //   const linked = linkWgsl(src, registry);
-//   expect(linked).contains("log(bar);");
-//   expect(linked).contains("fn log(logVar: i32) {}");
+//   expect(linked).toContain("log(bar);");
+//   expect(linked).toContain("fn log(logVar: i32) {}");
 // });

--- a/packages/linker/src/test/ModuleRegistry.test.ts
+++ b/packages/linker/src/test/ModuleRegistry.test.ts
@@ -12,7 +12,7 @@ test("findTextModule", () => {
   });
   const parsed = registry.parsed();
   const m = parsed.findTextModule("bar");
-  expect(m?.modulePath).eq("bar");
+  expect(m?.modulePath).toBe("bar");
 });
 
 test("getModuleExport", () => {
@@ -33,5 +33,5 @@ test("getModuleExport", () => {
   const impMod = parsed.findTextModule("./main")!;
 
   const m = parsed.getModuleExport(impMod, ["bar", "foo"]);
-  expect(m?.module.modulePath).eq("bar");
+  expect(m?.module.modulePath).toBe("bar");
 });

--- a/packages/linker/src/test/ParseComments.test.ts
+++ b/packages/linker/src/test/ParseComments.test.ts
@@ -10,13 +10,13 @@ import { testAppParse } from "./TestUtil.js";
 test("lineComment parse // foo bar", () => {
   const src = "// foo bar";
   const { position } = testAppParse(lineComment, src);
-  expect(position).eq(src.length);
+  expect(position).toBe(src.length);
 });
 
 test("lineComment parse // foo bar \\n", () => {
   const src = "// foo bar\n";
   const { position } = testAppParse(lineComment, src);
-  expect(position).eq(src.length);
+  expect(position).toBe(src.length);
 });
 
 test("blockComment parses /* comment */", () => {

--- a/packages/linker/src/test/ParseDirectives.test.ts
+++ b/packages/linker/src/test/ParseDirectives.test.ts
@@ -2,28 +2,22 @@ import { _withBaseLogger, tokens } from "mini-parse";
 import { logCatch } from "mini-parse/test-util";
 
 import { expect, test } from "vitest";
-import {
-  ModuleElem,
-  TreeImportElem
-} from "../AbstractElems.js";
+import { ModuleElem, TreeImportElem } from "../AbstractElems.js";
 import { SimpleSegment, treeToString } from "../ImportTree.js";
 import { argsTokens } from "../MatchWgslD.js";
-import {
-  directive,
-  importing
-} from "../ParseDirective.js";
+import { directive, importing } from "../ParseDirective.js";
 import { parseWgslD } from "../ParseWgslD.js";
 import { last } from "../Util.js";
 import { testAppParse } from "./TestUtil.js";
 
 test("directive parses #export", () => {
   const { appState } = testAppParse(directive, "#export");
-  expect(appState[0].kind).equals("export");
+  expect(appState[0].kind).toBe("export");
 });
 
 test("parse #export", () => {
   const parsed = parseWgslD("#export");
-  expect(parsed[0].kind).equals("export");
+  expect(parsed[0].kind).toBe("export");
 });
 
 test("parse import foo/bar", () => {
@@ -114,26 +108,26 @@ test("parse extends", () => {
 test("parse module foo.bar.ca", () => {
   const src = `module foo.bar.ca`;
   const appState = parseWgslD(src);
-  expect(appState[0].kind).eq("module");
-  expect((appState[0] as ModuleElem).name).eq("foo.bar.ca");
+  expect(appState[0].kind).toBe("module");
+  expect((appState[0] as ModuleElem).name).toBe("foo.bar.ca");
 });
 
 test("module foo.bar.ca", (ctx) => {
   const appState = parseWgslD(ctx.task.name);
-  expect(appState[0].kind).eq("module");
-  expect((appState[0] as ModuleElem).name).eq("foo.bar.ca");
+  expect(appState[0].kind).toBe("module");
+  expect((appState[0] as ModuleElem).name).toBe("foo.bar.ca");
 });
 
 test("module foo::bar::ba", (ctx) => {
   const appState = parseWgslD(ctx.task.name);
-  expect(appState[0].kind).eq("module");
-  expect((appState[0] as ModuleElem).name).eq("foo/bar/ba");
+  expect(appState[0].kind).toBe("module");
+  expect((appState[0] as ModuleElem).name).toBe("foo/bar/ba");
 });
 
 test("module foo/bar/ba", (ctx) => {
   const appState = parseWgslD(ctx.task.name);
-  expect(appState[0].kind).eq("module");
-  expect((appState[0] as ModuleElem).name).eq("foo/bar/ba");
+  expect(appState[0].kind).toBe("module");
+  expect((appState[0] as ModuleElem).name).toBe("foo/bar/ba");
 });
 
 test("parse import with numeric types", () => {
@@ -143,27 +137,27 @@ test("parse import with numeric types", () => {
 
   const segments = (appState[0] as TreeImportElem).imports.segments;
   const lastSegment = last(segments) as SimpleSegment;
-  expect(lastSegment.args).deep.eq(nums);
+  expect(lastSegment.args).toEqual(nums);
 });
 
 test("#import foo from ./util", (ctx) => {
   const appState = parseWgslD(ctx.task.name);
   const importElem = appState[0] as TreeImportElem;
   const segments = treeToString(importElem.imports);
-  expect(segments).eq("./util/foo");
+  expect(segments).toBe("./util/foo");
 });
 
 test('import { foo } from "./bar"', (ctx) => {
   const appState = parseWgslD(ctx.task.name);
   const importElem = appState[0] as TreeImportElem;
   const segments = treeToString(importElem.imports);
-  expect(segments).eq("./bar/foo");
+  expect(segments).toBe("./bar/foo");
 });
 
 test('import { foo, bar } from "./bar"', (ctx) => {
   const appState = parseWgslD(ctx.task.name);
   const imports = appState.filter((e) => e.kind === "treeImport");
   const segments = imports.map((i) => treeToString(i.imports));
-  expect(segments).includes("./bar/foo");
-  expect(segments).includes("./bar/bar");
+  expect(segments).toContain("./bar/foo");
+  expect(segments).toContain("./bar/bar");
 });

--- a/packages/linker/src/test/ParseModule.test.ts
+++ b/packages/linker/src/test/ParseModule.test.ts
@@ -37,8 +37,8 @@ test.skip("match #extends", () => {
   `;
   const module = testParseModule(src);
   const merges = module.structs[0].extendsElems!;
-  expect(merges[0].name).eq("Foo");
-  expect(merges[1].name).eq("Bar");
+  expect(merges[0].name).toBe("Foo");
+  expect(merges[1].name).toBe("Bar");
 });
 
 test("read simple struct export", () => {
@@ -73,9 +73,9 @@ test.skip("simple #template preserves src map", () => {
   `;
   const templates = new Map([["simple", simpleTemplate.apply]]);
   const textModule = parseModule(src, "./foo", { XX: "/**/" }, templates);
-  expect(textModule.preppedSrc).includes("fn foo() { /**/ }");
-  expect(textModule.preppedSrc).equals(expected);
-  expect(textModule.srcMap.entries).length(3);
+  expect(textModule.preppedSrc).toContain("fn foo() { /**/ }");
+  expect(textModule.preppedSrc).toBe(expected);
+  expect(textModule.srcMap.entries.length).toBe(3);
 });
 
 test.skip("parse error shows correct line after simple #template", () => {

--- a/packages/linker/src/test/ParseWgslD.test.ts
+++ b/packages/linker/src/test/ParseWgslD.test.ts
@@ -40,7 +40,7 @@ test("structDecl parses struct member types", () => {
   const { appState } = testAppParse(structDecl, src);
   const { members } = appState[0] as StructElem;
   const typeNames = members.flatMap((m) => m.typeRefs.map((t) => t.name));
-  expect(typeNames).deep.eq(["f32", "i32"]);
+  expect(typeNames).toEqual(["f32", "i32"]);
 });
 
 test("parse struct", () => {
@@ -210,7 +210,7 @@ test("fnDecl parses fn with return type", () => {
     fn foo() -> MyType { }
   `;
   const { appState } = testAppParse(fnDecl, src);
-  expect((appState[0] as FnElem).typeRefs[0].name).eq("MyType");
+  expect((appState[0] as FnElem).typeRefs[0].name).toBe("MyType");
 });
 
 test("fnDecl parses :type specifier in fn args", () => {
@@ -219,7 +219,7 @@ test("fnDecl parses :type specifier in fn args", () => {
   `;
   const { appState } = testAppParse(fnDecl, src);
   const { typeRefs } = appState[0] as FnElem;
-  expect(typeRefs[0].name).eq("MyType");
+  expect(typeRefs[0].name).toBe("MyType");
 });
 
 test("fnDecl parses :type specifier in fn block", () => {
@@ -229,7 +229,7 @@ test("fnDecl parses :type specifier in fn block", () => {
     }
   `;
   const { appState } = testAppParse(fnDecl, src);
-  expect((appState[0] as FnElem).typeRefs[0].name).eq("MyType");
+  expect((appState[0] as FnElem).typeRefs[0].name).toBe("MyType");
 });
 
 test("parse type in <template> in fn args", () => {
@@ -238,17 +238,17 @@ test("parse type in <template> in fn args", () => {
 
   const { appState } = testAppParse(fnDecl, src);
   const { typeRefs } = appState[0] as FnElem;
-  expect(typeRefs[0].name).eq("vec2");
-  expect(typeRefs[1].name).eq("MyStruct");
+  expect(typeRefs[0].name).toBe("vec2");
+  expect(typeRefs[1].name).toBe("MyStruct");
 });
 
 test("parse simple templated type", () => {
   const src = `array<MyStruct,4>`;
 
   const { parsed } = testAppParse(typeSpecifier, src);
-  expect(parsed?.value[0].name).eq("array");
-  expect(parsed?.value[1].name).eq("MyStruct");
-  expect(parsed?.value.length).eq(2);
+  expect(parsed?.value[0].name).toBe("array");
+  expect(parsed?.value[1].name).toBe("MyStruct");
+  expect(parsed?.value.length).toBe(2);
 });
 
 test("parse nested template that ends with >> ", () => {
@@ -256,7 +256,7 @@ test("parse nested template that ends with >> ", () => {
 
   const { parsed } = testAppParse(typeSpecifier, src);
   const typeRefNames = parsed?.value.map((r) => r.name);
-  expect(typeRefNames).deep.eq(["vec2", "array", "MyStruct"]);
+  expect(typeRefNames).toEqual(["vec2", "array", "MyStruct"]);
 });
 
 test("parse struct member with templated type", () => {
@@ -264,7 +264,7 @@ test("parse struct member with templated type", () => {
   const { appState } = testAppParse(structDecl, src);
   const members = filterElems<StructElem>(appState, "struct")[0].members;
   const memberNames = members.flatMap((m) => m.typeRefs.map((t) => t.name));
-  expect(memberNames).deep.eq(["vec2", "array", "Bar"]);
+  expect(memberNames).toEqual(["vec2", "array", "Bar"]);
 });
 
 test("parse type in <template> in global var", () => {
@@ -273,8 +273,8 @@ test("parse type in <template> in global var", () => {
 
   const { appState } = testAppParse(globalVar, src);
   const typeRefs = (appState[0] as VarElem).typeRefs;
-  expect(typeRefs[0].name).eq("vec2");
-  expect(typeRefs[1].name).eq("MyStruct");
+  expect(typeRefs[0].name).toBe("vec2");
+  expect(typeRefs[1].name).toBe("MyStruct");
 });
 
 test("parse for(;;) {} not as a fn call", () => {
@@ -286,7 +286,7 @@ test("parse for(;;) {} not as a fn call", () => {
   const appState = testParseWgsl(src);
   const fnElem = filterElems<FnElem>(appState, "fn")[0];
   expect(fnElem).toBeDefined();
-  expect(fnElem.calls.length).eq(0);
+  expect(fnElem.calls.length).toBe(0);
 });
 
 test("eolf followed by blank line", () => {
@@ -308,8 +308,8 @@ test("parse fn with attributes and suffix comma", () => {
   expectNoLogErr(() => {
     const parsed = testParseWgsl(src);
     const first = parsed[0] as FnElem;
-    expect(first.kind).eq("fn");
-    expect(first.name).eq("main");
+    expect(first.kind).toBe("fn");
+    expect(first.name).toBe("main");
   });
 });
 
@@ -347,5 +347,5 @@ test("parse var x: foo.bar;", () => {
   const parsed = testParseWgsl(src);
 
   const varRef = parsed.find((e) => e.kind === "var");
-  expect(varRef?.typeRefs[0].name).eq("foo.bar");
+  expect(varRef?.typeRefs[0].name).toBe("foo.bar");
 });

--- a/packages/linker/src/test/PathUtil.test.ts
+++ b/packages/linker/src/test/PathUtil.test.ts
@@ -5,30 +5,30 @@ import { normalize } from "../PathUtil.js";
 
 test("normalize ./foo", () => {
   const n = normalize("./foo");
-  expect(n).equals("foo");
+  expect(n).toBe("foo");
 });
 
 test("normalize ./foo/./", () => {
   const n = normalize("./foo/./");
-  expect(n).equals("foo");
+  expect(n).toBe("foo");
 });
 
 test("normalize foo/bar/..", () => {
   const n = normalize("foo/bar/..");
-  expect(n).equals("foo");
+  expect(n).toBe("foo");
 });
 
 test("normalize ./foo/bar/../.", () => {
   const n = normalize("./foo/bar/../.");
-  expect(n).equals("foo");
+  expect(n).toBe("foo");
 });
 
 test("normalize ../foo", () => {
   const n = normalize("../foo");
-  expect(n).equals("../foo");
+  expect(n).toBe("../foo");
 });
 
 test("normalize ../../foo", () => {
   const n = normalize("../../foo");
-  expect(n).equals("../../foo");
+  expect(n).toBe("../../foo");
 });

--- a/packages/linker/src/test/ResolveImport.test.ts
+++ b/packages/linker/src/test/ResolveImport.test.ts
@@ -27,8 +27,8 @@ test("resolveImport foo() from import bar/foo", () => {
 
   const found = resolveImport("foo", resolveMap);
   expect(found).toBeDefined();
-  expect(found?.modExp.module.modulePath).eq("bar");
-  expect((found?.modExp.exp as TextExport).ref.name).eq("foo");
+  expect(found?.modExp.module.modulePath).toBe("bar");
+  expect((found?.modExp.exp as TextExport).ref.name).toBe("foo");
 });
 
 test("resolveImport bar/foo() from import bar/foo", () => {
@@ -52,6 +52,6 @@ test("resolveImport bar/foo() from import bar/foo", () => {
   const resolveMap = importResolutionMap(impMod, treeImports, parsedModules);
   const found = resolveImport("bar.foo", resolveMap);
   expect(found).toBeDefined();
-  expect(found?.modExp.module.modulePath).eq("bar");
-  expect((found?.modExp.exp as TextExport).ref.name).eq("foo");
+  expect(found?.modExp.module.modulePath).toBe("bar");
+  expect((found?.modExp.exp as TextExport).ref.name).toBe("foo");
 });

--- a/packages/linker/src/test/Slicer.test.ts
+++ b/packages/linker/src/test/Slicer.test.ts
@@ -6,7 +6,7 @@ test("slice middle", () => {
   const src = "aaabbbc";
   const srcMap = sliceReplace(src, [{ start: 3, end: 6, replacement: "X" }]);
   const { dest, entries } = srcMap;
-  expect(dest).eq("aaaXc");
+  expect(dest).toBe("aaaXc");
   expect(entries).toMatchInlineSnapshot(`
     [
       {
@@ -37,7 +37,7 @@ test("slice middle", () => {
 test("slice end", () => {
   const src = "aaabbb";
   const srcMap = sliceReplace(src, [{ start: 3, end: 6, replacement: "X" }]);
-  expect(srcMap.dest).eq("aaaX");
+  expect(srcMap.dest).toBe("aaaX");
   validateDestCovered(srcMap);
 });
 
@@ -45,7 +45,7 @@ test("slice beginning", () => {
   const src = "aaabbb";
   const srcMap = sliceReplace(src, [{ start: 0, end: 3, replacement: "X" }]);
   validateDestCovered(srcMap);
-  expect(srcMap.dest).eq("Xbbb");
+  expect(srcMap.dest).toBe("Xbbb");
 });
 
 test("slice multiple", () => {
@@ -55,22 +55,22 @@ test("slice multiple", () => {
     { start: 0, end: 3, replacement: "A" },
   ]);
   validateDestCovered(srcMap);
-  expect(srcMap.dest).eq("ABc");
-  expect(srcMap.entries).length(3);
+  expect(srcMap.dest).toBe("ABc");
+  expect(srcMap.entries.length).toBe(3);
 });
 
 test("slice none", () => {
   const src = "aaabbbc";
   const srcMap = sliceReplace(src, []);
   validateDestCovered(srcMap);
-  expect(srcMap.dest).eq(src);
+  expect(srcMap.dest).toBe(src);
 });
 
 test("slice none with start and end", () => {
   const src = "aaabbbc";
   const srcMap = sliceReplace(src, [], 3, 6);
   validateDestCovered(srcMap);
-  expect(srcMap.dest).eq("bbb");
+  expect(srcMap.dest).toBe("bbb");
 });
 
 test("slice one with start and end", () => {
@@ -79,7 +79,7 @@ test("slice one with start and end", () => {
   const slices = [{ start: 3, end: 6, replacement: "B" }];
   const srcMap = sliceReplace(src, slices, 2);
   validateDestCovered(srcMap);
-  expect(srcMap.dest).eq("aBc");
+  expect(srcMap.dest).toBe("aBc");
 });
 
 test("slice with empty replacement", () => {
@@ -88,7 +88,7 @@ test("slice with empty replacement", () => {
   const slices = [{ start: 3, end: 6, replacement: "" }];
   const srcMap = sliceReplace(src, slices);
   validateDestCovered(srcMap);
-  expect(srcMap.dest).eq("aaac");
+  expect(srcMap.dest).toBe("aaac");
 });
 
 /** verify that the srcMap covers every part of the destination text */
@@ -96,8 +96,8 @@ function validateDestCovered(srcMap: SrcMap): void {
   const { dest, entries } = srcMap;
   let destPos = 0;
   entries.forEach((e) => {
-    expect(e.destStart).eq(destPos);
+    expect(e.destStart).toBe(destPos);
     destPos = e.destEnd;
   });
-  expect(destPos).eq(dest.length);
+  expect(destPos).toBe(dest.length);
 }

--- a/packages/linker/src/test/TraverseRefs.test.ts
+++ b/packages/linker/src/test/TraverseRefs.test.ts
@@ -23,9 +23,9 @@ test("traverse a fn to struct ref", () => {
 
   const refs = traverseTest(src, module1);
   const exp = refs[1] as TextRef;
-  expect(exp.kind).eq("txt");
-  expect(exp.elem.kind).eq("struct");
-  expect(exp.elem.name).eq("AStruct");
+  expect(exp.kind).toBe("txt");
+  expect(exp.elem.kind).toBe("struct");
+  expect(exp.elem.name).toBe("AStruct");
 });
 
 test("traverse simple gleam style import", () => {
@@ -39,9 +39,9 @@ test("traverse simple gleam style import", () => {
   `;
   const refs = traverseTest(main, bar);
   const exp = refs[1] as TextRef;
-  expect(exp.kind).eq("txt");
-  expect(exp.elem.kind).eq("fn");
-  expect(exp.elem.name).eq("foo");
+  expect(exp.kind).toBe("txt");
+  expect(exp.elem.kind).toBe("fn");
+  expect(exp.elem.name).toBe("foo");
 });
 
 test("traverse nested import with params and support fn", () => {
@@ -73,9 +73,9 @@ test("traverse nested import with params and support fn", () => {
   const first = refs[1] as TextRef;
   const second = refs[2] as TextRef;
   expect(first.kind).toBe("txt");
-  expect(first.expInfo?.expImpArgs).deep.eq([["A", "u32"]]);
+  expect(first.expInfo?.expImpArgs).toEqual([["A", "u32"]]);
   expect(second.kind).toBe("txt");
-  expect(second.elem.name).eq("support");
+  expect(second.elem.name).toBe("support");
 });
 
 test.skip("traverse importing", () => {
@@ -95,7 +95,7 @@ test.skip("traverse importing", () => {
   const refs = traverseTest(src, module1, module2);
 
   const importingRef = refs[2] as TextRef;
-  expect(importingRef.expInfo?.expImpArgs).deep.eq([["X", "B"]]);
+  expect(importingRef.expInfo?.expImpArgs).toEqual([["X", "B"]]);
 });
 
 test.skip("traverse double importing", () => {
@@ -120,8 +120,8 @@ test.skip("traverse double importing", () => {
     const er = r as TextRef;
     return er ? [er.expInfo?.expImpArgs] : [];
   });
-  expect(expImpArgs[2]).deep.eq([["X", "B"]]);
-  expect(expImpArgs[3]).deep.eq([["Y", "B"]]);
+  expect(expImpArgs[2]).toEqual([["X", "B"]]);
+  expect(expImpArgs[3]).toEqual([["Y", "B"]]);
 });
 
 test.skip("traverse importing from a support fn", () => {
@@ -167,7 +167,7 @@ test.skip("traverse importing from a local call fails", () => {
     fn bar(x:X) { } `;
 
   const { log } = traverseWithLog(src, module1, module2);
-  expect(log.length).not.eq(0);
+  expect(log.length).not.toBe(0);
 });
 
 test.skip("importing args don't match", () => {
@@ -269,9 +269,9 @@ test("traverse a global var to struct ref", () => {
 
   const refs = traverseTest(src, module1);
   const exp = refs[1] as TextRef;
-  expect(exp.kind).eq("txt");
-  expect(exp.elem.kind).eq("struct");
-  expect(exp.elem.name).eq("Uniforms");
+  expect(exp.kind).toBe("txt");
+  expect(exp.elem.kind).toBe("struct");
+  expect(exp.elem.name).toBe("Uniforms");
 });
 
 test("traverse transitive struct refs", () => {
@@ -383,7 +383,7 @@ test("traverse with local support struct", () => {
 
   const refs = traverseTest(src, module1);
   const refNames = refs.map(refName);
-  expect(refNames).deep.eq(["B", "b", "A"]);
+  expect(refNames).toEqual(["B", "b", "A"]);
 });
 
 test("traverse from return type of function", () => {
@@ -399,7 +399,7 @@ test("traverse from return type of function", () => {
 
   const refs = traverseTest(src, module1);
   const refNames = refs.map(refName);
-  expect(refNames).deep.eq(["b", "A"]);
+  expect(refNames).toEqual(["b", "A"]);
 });
 
 test("traverse skips built in fn and type", () => {
@@ -415,8 +415,8 @@ test("traverse skips built in fn and type", () => {
   const { refs, log } = traverseWithLog(src);
   const refNames = refs.map(refName);
   // refs.map(r => refLog(r));
-  expect(refNames).deep.eq(["foo", "bar"]);
-  expect(log).eq("");
+  expect(refNames).toEqual(["foo", "bar"]);
+  expect(log).toBe("");
 });
 
 test("type inside fn with same name as fn", () => {
@@ -428,8 +428,8 @@ test("type inside fn with same name as fn", () => {
     fn bar() {}
   `;
   const { refs, log } = traverseWithLog(src);
-  expect(log).is.empty;
-  expect(refs).length(2);
+  expect(log).toBe("");
+  expect(refs.length).toBe(2);
 });
 
 test("call inside fn with same name as fn", () => {
@@ -439,8 +439,8 @@ test("call inside fn with same name as fn", () => {
     }
   `;
   const { refs, log } = traverseWithLog(src);
-  expect(refs).length(1);
-  expect(log).is.empty;
+  expect(refs.length).toBe(1);
+  expect(log).toBe("");
 });
 
 test("call cross reference", () => {
@@ -455,10 +455,10 @@ test("call cross reference", () => {
   `;
   const { refs, log } = traverseWithLog(src);
   const refNames = refs.map((r) => (r as TextRef).elem.name);
-  expect(refNames).contains("foo");
-  expect(refNames).contains("bar");
-  expect(refNames).length(2);
-  expect(log).is.empty;
+  expect(refNames).toContain("foo");
+  expect(refNames).toContain("bar");
+  expect(refNames.length).toBe(2);
+  expect(log).toBe("");
 });
 
 test("struct self reference", () => {
@@ -472,7 +472,7 @@ test("struct self reference", () => {
     }
   `;
   const { log } = traverseWithLog(src);
-  expect(log).is.empty;
+  expect(log).toBe("");
 });
 
 test("struct cross reference", () => {
@@ -485,17 +485,17 @@ test("struct cross reference", () => {
     }
   `;
   const { refs, log } = traverseWithLog(src);
-  expect(log).is.empty;
+  expect(log).toBe("");
   const refNames = refs.map((r) => (r as any).elem.name);
-  expect(refNames).includes("A");
-  expect(refNames).includes("B");
-  expect(refNames).length(2);
+  expect(refNames).toContain("A");
+  expect(refNames).toContain("B");
+  expect(refNames.length).toBe(2);
 });
 
 test("parse texture_storage_2d with texture format in type position", () => {
   const src = `var t: texture_storage_2d<rgba8unorm, write>;`;
   const { log } = traverseWithLog(src);
-  expect(log).is.empty;
+  expect(log).toBe("");
 });
 
 /** run traverseRefs with no filtering and return the refs and the error log output */

--- a/packages/linker/src/test/Util.test.ts
+++ b/packages/linker/src/test/Util.test.ts
@@ -3,20 +3,20 @@ import { overlapTail, scan } from "../Util.js";
 
 test("scan", () => {
   const result = scan([1, 2, 1], (a, b: string) => b.slice(a), "foobar");
-  expect(result).deep.equals(["foobar", "oobar", "bar", "ar"]);
+  expect(result).toEqual(["foobar", "oobar", "bar", "ar"]);
 });
 
 test("overlap 0", () => {
   const result = overlapTail([2, 3], [4, 5]);
-  expect(result).undefined;
+  expect(result).toBeUndefined();
 });
 
 test("overlap 1", () => {
   const result = overlapTail([2, 3], [3, 4, 5]);
-  expect(result).deep.equals([4, 5]);
+  expect(result).toEqual([4, 5]);
 });
 
 test("overlap 2", () => {
   const result = overlapTail([2, 3], [2, 3]);
-  expect(result).deep.equals([]);
+  expect(result).toEqual([]);
 });

--- a/packages/linker/src/test/shared/test/StringUtil.test.ts
+++ b/packages/linker/src/test/shared/test/StringUtil.test.ts
@@ -3,7 +3,7 @@ import { trimSrc } from "../StringUtil.js";
 
 test("trimSrc on blank", () => {
   const trimmed = trimSrc(``);
-  expect(trimmed).eq("");
+  expect(trimmed).toBe("");
 });
 
 test("trimSrc with leading blank lines", () => {
@@ -12,7 +12,7 @@ test("trimSrc with leading blank lines", () => {
     fn foo() {
       // bar
     }`);
-  expect(trimmed).eq("fn foo() {\n  // bar\n}");
+  expect(trimmed).toBe("fn foo() {\n  // bar\n}");
 });
 
 test("trimSrc with blank line in the middle and at end", () => {
@@ -23,10 +23,10 @@ test("trimSrc with blank line in the middle and at end", () => {
       bar
      `
   );
-  expect(trimmed).eq("foo\n\nbar");
+  expect(trimmed).toBe("foo\n\nbar");
 });
 
 test("trimSrc with trailing spaces", () => {
-  const trimmed = trimSrc( ` foo `);
-  expect(trimmed).eq("foo");
+  const trimmed = trimSrc(` foo `);
+  expect(trimmed).toBe("foo");
 });

--- a/packages/mini-parse/src/test-util/TestParse.ts
+++ b/packages/mini-parse/src/test-util/TestParse.ts
@@ -51,7 +51,7 @@ export function testParse<T, N extends TagRecord = NoTags, S = any>(
 export function expectNoLogErr<T>(fn: () => T): T {
   const { log, logged } = logCatch();
   const result = _withBaseLogger(log, fn);
-  expect(logged()).eq("");
+  expect(logged()).toBe("");
   return result;
 }
 

--- a/packages/mini-parse/src/test/BlogExample.test.ts
+++ b/packages/mini-parse/src/test/BlogExample.test.ts
@@ -78,6 +78,6 @@ test("parse fn foo() with tagged results", () => {
     const [fnName] = result.tags.fnName;
     expect(fnName).toBe("foo");
     const annotations: string[] = result.tags.annotation;
-    expect(annotations).to.deep.eq(["export"]);
+    expect(annotations).to.toEqual(["export"]);
   }
 });

--- a/packages/mini-parse/src/test/CalculatorExample.test.ts
+++ b/packages/mini-parse/src/test/CalculatorExample.test.ts
@@ -6,35 +6,35 @@ import {
   simpleSum,
   simpleTokens,
   sumResults,
-  taggedSum
+  taggedSum,
 } from "../examples/DocExamples.js";
 
 test("parse 3 + 4", () => {
   const src = "3 + 4";
   const parsed = testParse(statement, src, calcTokens);
-  expect(parsed.position).eq(src.length);
+  expect(parsed.position).toBe(src.length);
 });
 
 test("parse 3 + 4 + 7", () => {
   const src = "3 + 4 + 7";
   const parsed = testParse(statement, src, calcTokens);
-  expect(parsed.position).eq(src.length);
+  expect(parsed.position).toBe(src.length);
 });
 
 test("simple sum", () => {
   const lexer = matchingLexer("4 + 8", simpleTokens);
   const results = simpleSum.parse({ lexer });
-  expect(results?.value).deep.eq(["4", "+", "8"]);
+  expect(results?.value).toEqual(["4", "+", "8"]);
 });
 
 test("simple sum results ", () => {
   const lexer = matchingLexer("3 + 12", simpleTokens);
   const results = sumResults.parse({ lexer });
-  expect(results?.value).eq(15);
+  expect(results?.value).toBe(15);
 });
 
 test("tagged sum results ", () => {
   const lexer = matchingLexer("1 + 2 + 9", simpleTokens);
   const results = taggedSum.parse({ lexer });
-  expect(results?.value).eq(12);
+  expect(results?.value).toBe(12);
 });

--- a/packages/mini-parse/src/test/CalculatorResultsExample.test.ts
+++ b/packages/mini-parse/src/test/CalculatorResultsExample.test.ts
@@ -4,45 +4,45 @@ import {
   power,
   product,
   resultsStatement,
-  sum
+  sum,
 } from "../examples/CalculatorResultsExample.js";
 import { Parser } from "../Parser.js";
 import { testParse } from "mini-parse/test-util";
 
 test("power 2 ^ 4", () => {
   const { parsed } = testParse(power, "2 ^ 3", calcTokens);
-  expect(parsed?.value).eq(8);
+  expect(parsed?.value).toBe(8);
 });
 
 test("product 3 * 4 ", () => {
   const { parsed } = testParse(product, "3 * 4", calcTokens);
-  expect(parsed?.value).eq(12);
+  expect(parsed?.value).toBe(12);
 });
 
 test("sum 3 + 4 ", () => {
   const { parsed } = testParse(sum, "3 + 4", calcTokens);
-  expect(parsed?.value).eq(7);
+  expect(parsed?.value).toBe(7);
 });
 
 test("parse 3 + 4 * 8", () => {
   const result = calcTest(resultsStatement, "3 + 4 * 8");
-  expect(result).eq(35);
+  expect(result).toBe(35);
 });
 
 test("parse 3 * 4 + 8", () => {
   const result = calcTest(resultsStatement, "3 * 4 + 8");
-  expect(result).eq(20);
+  expect(result).toBe(20);
 });
 
 test("parse 3^2 * 4 + 11", () => {
   const result = calcTest(resultsStatement, "3^2 *4 + 11");
-  expect(result).eq(47);
+  expect(result).toBe(47);
 });
 
 test("parse 2^4^2", () => {
   const result = calcTest(resultsStatement, "2^4^2");
-  expect(result).eq(2**4**2);
-})
+  expect(result).toBe(2 ** (4 ** 2));
+});
 
 function calcTest(parser: Parser<number>, src: string): number | undefined {
   const { parsed } = testParse(parser, src, calcTokens);

--- a/packages/mini-parse/src/test/ParserCombinator.test.ts
+++ b/packages/mini-parse/src/test/ParserCombinator.test.ts
@@ -76,21 +76,21 @@ test("tagged kind match", () => {
   const src = "foo";
   const p = kind(m.word).tag("nn");
   const { parsed } = testParse(p, src);
-  expect(parsed?.tags.nn).deep.equals(["foo"]);
+  expect(parsed?.tags.nn).toEqual(["foo"]);
 });
 
 test("seq() with tagged result", () => {
   const src = "#import foo";
   const p = seq("#import", kind(m.word).tag("yo"));
   const { parsed } = testParse(p, src);
-  expect(parsed?.tags.yo).deep.equals(["foo"]);
+  expect(parsed?.tags.yo).toEqual(["foo"]);
 });
 
 test("opt() makes failing match ok", () => {
   const src = "foo";
   const p = seq(opt("#import"), kind("word"));
   const { parsed } = testParse(p, src);
-  expect(parsed).not.null;
+  expect(parsed).not.toBeNull();
   expect(parsed).toMatchSnapshot();
 });
 
@@ -100,8 +100,8 @@ test("repeat() to (1,2,3,4) via tag", () => {
   const params = seq(opt(wordNum), opt(repeat(seq(",", wordNum))));
   const p = seq("(", params, ")");
   const { parsed } = testParse(p, src);
-  expect(parsed).not.null;
-  expect(parsed?.tags.wn).deep.equals(["1", "2", "3", "4"]);
+  expect(parsed).not.toBeNull();
+  expect(parsed?.tags.wn).toEqual(["1", "2", "3", "4"]);
 });
 
 test("map()", () => {
@@ -110,7 +110,7 @@ test("map()", () => {
     .tag("word")
     .map((r) => (r.tags.word?.[0] === "foo" ? "found" : "missed"));
   const { parsed } = testParse(p, src);
-  expect(parsed?.value).equals("found");
+  expect(parsed?.value).toBe("found");
 });
 
 test("toParser()", () => {
@@ -120,7 +120,7 @@ test("toParser()", () => {
     .tag("word")
     .toParser(() => bang);
   const { parsed } = testParse(p, src);
-  expect(parsed?.tags.bang).deep.equals(["!"]);
+  expect(parsed?.tags.bang).toEqual(["!"]);
 });
 
 test("not() success", () => {
@@ -136,7 +136,7 @@ test("not() failure", () => {
   const src = "foo";
   const p = not(kind(m.word));
   const { parsed } = testParse(p, src);
-  expect(parsed).null;
+  expect(parsed).toBeNull();
 });
 
 test("recurse with fn()", () => {
@@ -148,7 +148,7 @@ test("recurse with fn()", () => {
   );
   const wrap = or(p).map((r) => r.app.state.push(r.tags.word));
   const { appState: app } = testParse(wrap, src);
-  expect(app[0]).deep.equals(["a", "b"]);
+  expect(app[0]).toEqual(["a", "b"]);
 });
 
 test("tracing", () => {
@@ -171,7 +171,7 @@ test("infinite loop detection", () => {
     testParse(p, "y");
   });
 
-  expect(logged()).includes("infinite");
+  expect(logged()).toContain("infinite");
 });
 
 test("preparse simple comment", () => {
@@ -185,7 +185,7 @@ test("preparse simple comment", () => {
   const src = "boo /* bar */ baz";
 
   const { parsed } = testParse(p, src);
-  expect(parsed?.value).deep.eq(["boo", "baz"]);
+  expect(parsed?.value).toEqual(["boo", "baz"]);
 });
 
 test("disable preParse inside quote", () => {
@@ -214,7 +214,7 @@ test("disable preParse inside quote", () => {
   const src = "zug ^zip /* boo */^ zax";
 
   const { parsed } = testParse(p, src);
-  expect(parsed?.value).deep.eq(["zug", "zip /* boo */", "zax"]);
+  expect(parsed?.value).toEqual(["zug", "zip /* boo */", "zax"]);
 });
 
 test("disablePreParse restores preParse context", () => {
@@ -243,7 +243,7 @@ test("disablePreParse restores preParse context", () => {
     const src = "/*boo*/ 'za x' /*foo*/";
 
     const { parsed } = testParse(p, src);
-    expect(parsed?.value).deep.eq(["za x"]);
+    expect(parsed?.value).toEqual(["za x"]);
     expect(misParsed).false;
   });
 });
@@ -252,17 +252,17 @@ test("tokenIgnore", () => {
   const p = repeat(any()).map((r) => r.value.map((tok) => tok.text));
   const src = "a b";
   const { parsed: parsedNoSpace } = testParse(p, src);
-  expect(parsedNoSpace?.value).deep.eq(["a", "b"]);
+  expect(parsedNoSpace?.value).toEqual(["a", "b"]);
 
   const { parsed } = testParse(tokenSkipSet(null, p), src);
-  expect(parsed?.value).deep.eq(["a", " ", "b"]);
+  expect(parsed?.value).toEqual(["a", " ", "b"]);
 });
 
 test("token start is after ignored ws", () => {
   const src = " a";
   const p = kind(m.word).map((r) => r.start);
   const { parsed } = testParse(p, src);
-  expect(parsed?.value).eq(1);
+  expect(parsed?.value).toBe(1);
 });
 
 test("req logs a message on failure", () => {
@@ -285,14 +285,14 @@ test("repeatWhile", () => {
   const p = repeatWhile("a", () => count++ < 2);
   const src = "a a a a";
   const { parsed } = testParse(p, src);
-  expect(parsed?.value).deep.eq(["a", "a"]);
+  expect(parsed?.value).toEqual(["a", "a"]);
 });
 
 test("repeat1", () => {
   const p = repeatPlus("a");
   const src = "a a";
   const { parsed } = testParse(p, src);
-  expect(parsed?.value).deep.eq(["a", "a"]);
+  expect(parsed?.value).toEqual(["a", "a"]);
 });
 
 test("repeat1 fails", () => {
@@ -311,7 +311,7 @@ test("withTags blocks tags accumulation", () => {
   const s = seq(p.tag("w")).map((r) => r.tags.w);
 
   const { parsed } = testParse(s, "a b");
-  expect(parsed?.value).deep.eq([["a"]]); // a prev bug returned ["a", [["a"]]]
+  expect(parsed?.value).toEqual([["a"]]); // a prev bug returned ["a", [["a"]]]
 });
 
 test("withTags blocks tags from map()", () => {
@@ -327,20 +327,20 @@ test("withTags blocks tags from map()", () => {
   const cleared = c.map((r) => (clearedTags = r.tags));
   testParse(cleared, "foo");
 
-  expect(taggedTags).deep.eq({ w: ["foo"] });
-  expect(clearedTags).deep.eq({});
+  expect(taggedTags).toEqual({ w: ["foo"] });
+  expect(clearedTags).toEqual({});
 });
 
 test("withSep", () => {
   const src = "a, b, c";
   const p = withSep(",", kind(m.word).tag("w"));
   const result = testParse(p, src);
-  expect(result.parsed?.tags).deep.eq({ w: ["a", "b", "c"] });
+  expect(result.parsed?.tags).toEqual({ w: ["a", "b", "c"] });
 });
 
 test("tag follows setTraceName of orig", () => {
   const orig = kind(m.word);
   const tagged = orig.tag("w");
   setTraceName(orig, "orig");
-  expect(tagged.debugName).eq("orig");
+  expect(tagged.debugName).toBe("orig");
 });

--- a/packages/mini-parse/src/test/ParserLogging.test.ts
+++ b/packages/mini-parse/src/test/ParserLogging.test.ts
@@ -10,19 +10,19 @@ test("srcLine", () => {
   const src = [src1, src2, src3].join("\n");
 
   const { line: line1 } = srcLine(src, 0);
-  expect(line1).equals(src1);
+  expect(line1).toBe(src1);
 
   const { line: line4 } = srcLine(src, 1);
-  expect(line4).eq(src1);
+  expect(line4).toBe(src1);
 
   const { line: line5 } = srcLine(src, 2);
-  expect(line5).eq(src2);
+  expect(line5).toBe(src2);
 
   const { line: line2 } = srcLine(src, 3);
-  expect(line2).eq(src2);
+  expect(line2).toBe(src2);
 
   const { line: line3 } = srcLine(src, 100);
-  expect(line3).eq(src3);
+  expect(line3).toBe(src3);
 });
 
 test("srcLog", () => {


### PR DESCRIPTION
This makes it both easier to read the tests, and easier to migrate them to Deno's testing API.